### PR TITLE
Enable multiple sessions

### DIFF
--- a/backend/jobs.py
+++ b/backend/jobs.py
@@ -1,0 +1,23 @@
+from collections import defaultdict
+from typing import List
+import uuid
+
+class Job:
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        self.messages: List[dict] = []
+
+    def add_message(self, role: str, content: str):
+        self.messages.append({"role": role, "content": content})
+
+    def get_history(self) -> List[dict]:
+        return self.messages
+
+    def clear(self):
+        self.messages.clear()
+
+# Global in memory store for jobs
+job_store = defaultdict(lambda: Job(session_id=str(uuid.uuid4())))
+
+def get_job(session_id: str) -> Job:
+    return job_store[session_id]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "axios": "^1.10.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -2949,6 +2950,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "axios": "^1.10.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,21 +1,33 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import axios from 'axios';
 import './App.css';
+import { v4 as uuidv4 } from 'uuid';
 
 function App() {
-  const [input, setInput] = useState('');
+  const [sessionId, setSessionId] = useState('');
   const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    const id = uuidv4();
+    setSessionId(id);
+  }, []);
 
   const handleSend = async () => {
     if (!input.trim()) return;
 
     const userMessage = { sender: 'user', text: input };
-    const updatedMessages = [...messages, userMessage];
-    setMessages(updatedMessages);
+    setMessages((prev) => [...prev, userMessage]);
+
+    console.log("Sending to backend:", {
+      session_id: sessionId,
+      message: input
+    });
 
     try {
       const res = await axios.post('http://localhost:8000/chat', {
-        messages: updatedMessages,
+        session_id: sessionId,
+        message: input
       });
 
       const botMessage = { sender: 'bot', text: res.data.response };
@@ -23,7 +35,7 @@ function App() {
     } catch (err) {
       setMessages((prev) => [
         ...prev,
-        { sender: 'bot', text: 'Error: ' + err.message },
+        { sender: 'bot', text: 'Error: ' + err.message }
       ]);
     }
 


### PR DESCRIPTION
Implementing Unique Session IDs for Multiple Concurrent Conversations

To prevent interference between chat sessions, introduce a unique identifier for each conversation. This will enable the creation of separate, isolated sessions on different pages, ensuring that interactions between them do not overlap or compromise user experience.
